### PR TITLE
Remove non-word chars from filenames created with the files option

### DIFF
--- a/profiler.rb
+++ b/profiler.rb
@@ -126,7 +126,7 @@ module Profiler
       @table = col_details[:file]
       @column = col_details[:column]
       @index = col_details[:index]
-      @outpath = File.join(col_details[:outpath], filename)
+      @outpath = File.join(col_details[:outpath], filename.gsub(/\W+/,'_'))
       write_headers unless File.exist?(@outpath)
       append_report
     end


### PR DESCRIPTION
Little tweak to replace non-word chars in filenames created by the profiler.  Slashes in column headings are bad :-)